### PR TITLE
Fix schema information overwritten issue

### DIFF
--- a/src/REFormsEnhance.js
+++ b/src/REFormsEnhance.js
@@ -69,14 +69,30 @@ export default function REFormsEnhance( Component, schema ) {
   )( EnhancedComponent );
 }
 
-
+/**
+ * Clone an object or an array recursively
+ */
+function cloneObjectRecursive(object) {
+  let returnObject = null;
+  if(Object.prototype.toString.call(object) === '[object Object]') {
+    returnObject = {};
+  } else if(Object.prototype.toString.call(object) === '[object Array]') {
+    returnObject = [];
+  } else {
+    return object;
+  }
+  for(let indexKey in object) {
+    returnObject[indexKey] = cloneObjectRecursive(object[indexKey]);
+  }
+  return returnObject;
+}
 /**
  * Parse user's schema, create a "mirror" data structure called 'fns', containing user's validators and filters
  * Add remaining expected state-related props to each field in schema
  * Return a new object, containing both data and fns
  */
 export function _parseSchema( schema ) {
-  let data = { ...schema };
+  let data = cloneObjectRecursive(schema);
   let fns  = {};
 
   Object.keys( data ).forEach( ( formKey ) => {
@@ -99,7 +115,7 @@ export function _parseSchema( schema ) {
 
       // store initial value under 'valuePristine'
       const value = data[ formKey ][ fieldKey ].value;
-      data[ formKey ][ fieldKey ].valuePristine = fieldObj.multiple ? [ ...value ] : value;       // make a copy for arrays
+      data[ formKey ][ fieldKey ].valuePristine = fieldObj.multiple ? cloneObjectRecursive(value) : value;       // make a copy for arrays
 
     });
   });


### PR DESCRIPTION
    Schema information was replaced in _parseSchema function.
    Root cause is that ... expand all fields but not recursively.
    Add cloneObjectRecursive function to prevent this issue.