### PR TITLE
Add drop API for dropping unnecessary form data in Redux

### DIFF
--- a/src/REFormsAPI.js
+++ b/src/REFormsAPI.js
@@ -1,4 +1,4 @@
-import { updateFieldsAction } from './REFormsActions';
+import { updateFieldsAction, dropFormsAction } from './REFormsActions';
 import * as __ from './utils';
 
 /* -------------------- CONST -------------------- */
@@ -367,6 +367,16 @@ export function setServerErrors( libData, setData={}, formKey='' ) {
   _dispatchUpdateFieldsAction( dispatch, fieldSetList, fns, WARN_SET_SERVER_ERRORS );
 }
 
+/**
+ * Drop Form data from Redux.
+ * Example: f.drop( 'userForm' ) or f.drop( ['userForm', 'profileForm'] )
+ * @param {(string|string[])} [formKeys] - The formKey(s) of the form(s) data to be dropped, or no arg to drop all.
+ */
+export function drop( libData, formKeys='' ) {
+  const { dispatch } = libData;
+
+  dispatch( dropFormsAction( formKeys ) );
+}
 
 /* -------------------- PRIVATE API HELPERS -------------------- */
 

--- a/src/REFormsActions.js
+++ b/src/REFormsActions.js
@@ -1,5 +1,6 @@
 export const REFORMS_INIT          = 'REFORMS_INIT';
 export const REFORMS_UPDATE_FIELDS = 'REFORMS_UPDATE_FIELDS';
+export const REFORMS_DROP          = 'REFORMS_DROP';
 
 
 export function initFormsAction( data, fns ) {
@@ -15,5 +16,12 @@ export function updateFieldsAction( fieldUpdateList, fns ) {
     type: REFORMS_UPDATE_FIELDS,
     fieldUpdateList,
     fns
+  };
+}
+
+export function dropFormsAction( dropFormKeys ) {
+  return {
+    type: REFORMS_DROP,
+    dropFormKeys
   };
 }

--- a/src/REFormsEnhance.js
+++ b/src/REFormsEnhance.js
@@ -58,7 +58,8 @@ export default function REFormsEnhance( Component, schema ) {
         isFormDirty:     _apiEnhance( api.isFormDirty,     libData ),
         setPristine:     _apiEnhance( api.setPristine,     libData ),
         setFormPristine: _apiEnhance( api.setFormPristine, libData ),
-        setServerErrors: _apiEnhance( api.setServerErrors, libData )
+        setServerErrors: _apiEnhance( api.setServerErrors, libData ),
+        drop:            _apiEnhance( api.drop, libData )
       };
 
       return <Component REForms={ enhancedAPI } { ...rest } />;

--- a/src/REFormsReducer.js
+++ b/src/REFormsReducer.js
@@ -1,4 +1,4 @@
-import { REFORMS_INIT, REFORMS_UPDATE_FIELDS } from './REFormsActions';
+import { REFORMS_INIT, REFORMS_UPDATE_FIELDS, REFORMS_DROP } from './REFormsActions';
 
 import * as __ from './utils';
 
@@ -115,6 +115,27 @@ export default function REFormsReducer( state={}, action ) {
         return clonedState;
       }
 
+    /*
+     * Drop user's REForms data set from Redux
+     */
+    case REFORMS_DROP:
+      {
+        const dropFormKeys = action.dropFormKeys;
+        let clonedState    = __.cloneObject( state );
+
+        // no arg means drop all forms.
+        if(!dropFormKeys) return {};
+
+        if( Array.isArray(dropFormKeys) ) {
+          dropFormKeys.forEach( (dropFormKey) => {
+            delete clonedState[dropFormKey];
+          });
+        } else {
+          delete clonedState[dropFormKeys];
+        }
+
+        return clonedState;
+      }
 
     /*
      * Fallback


### PR DESCRIPTION
Sometimes we want a clean form when re-visiting. The old form data should be dropped when unmount form if we don't need it anymore. Therefore, add this API and developers could do what they want.